### PR TITLE
日時表示を日本時間に変更

### DIFF
--- a/config/application.rb
+++ b/config/application.rb
@@ -20,5 +20,7 @@ module Mynote
     # Application configuration can go into files in config/initializers
     # -- all .rb files in that directory are automatically loaded after loading
     # the framework and any gems in your application.
+    config.i18n.default_locale = :ja
+    config.time_zone = 'Tokyo'
   end
 end


### PR DESCRIPTION
# What
日時表示を日本時間に変更

# Why
Railsのアプリケーションの時間基準は、デフォルトでは協定時(UTC)となっているため、日本時間に変更